### PR TITLE
Always use the 32-bit max index for arrays in SGen's create_allocator () 

### DIFF
--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -152,16 +152,22 @@
 
 #endif
 
+#define MONO_ARRAY_MAX_INDEX_32 G_MAXINT32
+#define MONO_ARRAY_MAX_INDEX_64 G_MAXINT64
+
+#define MONO_ARRAY_MAX_SIZE_32  G_MAXUINT32
+#define MONO_ARRAY_MAX_SIZE_64  G_MAXUINT64
+
 #if SIZEOF_VOID_P == 8
 typedef uint64_t mono_array_size_t;
 typedef int64_t mono_array_lower_bound_t;
-#define MONO_ARRAY_MAX_INDEX G_MAXINT64
-#define MONO_ARRAY_MAX_SIZE  G_MAXUINT64
+#define MONO_ARRAY_MAX_INDEX MONO_ARRAY_MAX_INDEX_64
+#define MONO_ARRAY_MAX_SIZE  MONO_ARRAY_MAX_SIZE_64
 #else
 typedef uint32_t mono_array_size_t;
 typedef int32_t mono_array_lower_bound_t;
-#define MONO_ARRAY_MAX_INDEX ((int32_t) 0x7fffffff)
-#define MONO_ARRAY_MAX_SIZE  ((uint32_t) 0xffffffff)
+#define MONO_ARRAY_MAX_INDEX MONO_ARRAY_MAX_INDEX_32
+#define MONO_ARRAY_MAX_SIZE  MONO_ARRAY_MAX_SIZE_32
 #endif
 
 typedef struct {

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -4683,14 +4683,14 @@ mono_array_new_full (MonoDomain *domain, MonoClass *array_class, uintptr_t *leng
 	/* A single dimensional array with a 0 lower bound is the same as an szarray */
 	if (array_class->rank == 1 && ((array_class->byval_arg.type == MONO_TYPE_SZARRAY) || (lower_bounds && lower_bounds [0] == 0))) {
 		len = lengths [0];
-		if (len > MONO_ARRAY_MAX_INDEX)//MONO_ARRAY_MAX_INDEX
+		if (len > MONO_ARRAY_MAX_INDEX)
 			arith_overflow ();
 		bounds_size = 0;
 	} else {
 		bounds_size = sizeof (MonoArrayBounds) * array_class->rank;
 
 		for (i = 0; i < array_class->rank; ++i) {
-			if (lengths [i] > MONO_ARRAY_MAX_INDEX) //MONO_ARRAY_MAX_INDEX
+			if (lengths [i] > MONO_ARRAY_MAX_INDEX)
 				arith_overflow ();
 			if (CHECK_MUL_OVERFLOW_UN (len, lengths [i]))
 				mono_gc_out_of_memory (MONO_ARRAY_MAX_SIZE);

--- a/mono/metadata/sgen-gc.c
+++ b/mono/metadata/sgen-gc.c
@@ -7055,9 +7055,9 @@ create_allocator (int atype)
 		MonoClass *oom_exc_class;
 		MonoMethod *ctor;
 
-		/* n > 	MONO_ARRAY_MAX_INDEX -> OverflowException */
+		/* n > 	MONO_ARRAY_MAX_INDEX_32 -> OverflowException */
 		mono_mb_emit_ldarg (mb, 1);
-		mono_mb_emit_icon (mb, MONO_ARRAY_MAX_INDEX);
+		mono_mb_emit_icon (mb, MONO_ARRAY_MAX_INDEX_32);
 		pos = mono_mb_emit_short_branch (mb, CEE_BLE_UN_S);
 		mono_mb_emit_exception (mb, "OverflowException", NULL);
 		mono_mb_patch_short_branch (mb, pos);


### PR DESCRIPTION
Always use the 32-bit max index for arrays in SGen's create_allocator () for ATYPE_VECTOR.
